### PR TITLE
Remove unused docker-buildx package from runner image + Add ~/.local/bin to PATH

### DIFF
--- a/runner/Dockerfile.ubuntu
+++ b/runner/Dockerfile.ubuntu
@@ -885,6 +885,8 @@ COPY --from=docker-buildx  /usr/local/lib/docker/cli-plugins/docker-buildx  /usr
 WORKDIR /home/runner
 USER runner
 
+ENV PATH=/home/runner/.local/bin:${PATH}
+
 ARG RUNNER_VERSION=2.331.0
 RUN bash -eux -o pipefail <<'EOF'
     curl -L https://github.com/alitariq4589/github-runner-riscv/releases/download/v${RUNNER_VERSION}-riscv64-net8/actions-runner-linux-riscv64-${RUNNER_VERSION}.tar.gz \


### PR DESCRIPTION
The plugin is manually downloaded from github into /usr/local/lib/docker/cli-plugins