### PR TITLE
Add gettext-base package

### DIFF
--- a/runner/Dockerfile.ubuntu
+++ b/runner/Dockerfile.ubuntu
@@ -747,6 +747,7 @@ RUN bash -eux -o pipefail <<'EOF'
         ftp \
         g++ \
         g++-14 \
+        gettext-base \
         gcc \
         gcc-14 \
         git \


### PR DESCRIPTION
Provide envsubst command available to GitHub Actions by installing gettext-base package

Resolves riseproject-dev/riscv-runner-images#38