### PR TITLE
runner: add clang and libclang-dev to Ubuntu image

### DIFF
--- a/runner/Dockerfile.ubuntu
+++ b/runner/Dockerfile.ubuntu
@@ -730,6 +730,7 @@ RUN bash -eux -o pipefail <<'EOF'
         bzip2 \
         ca-certificates \
         ccache \
+        clang \
         cmake \
         coreutils \
         curl \
@@ -758,6 +759,7 @@ RUN bash -eux -o pipefail <<'EOF'
         iputils-ping \
         jq \
         libatomic1 \
+        libclang-dev \
         libbz2-1.0 \
         libexpat1 \
         libffi8 \

--- a/runner/Dockerfile.ubuntu
+++ b/runner/Dockerfile.ubuntu
@@ -730,7 +730,9 @@ RUN bash -eux -o pipefail <<'EOF'
         bzip2 \
         ca-certificates \
         ccache \
-        clang \
+        clang-{16,17,18} \
+        clang-tidy-{16,17,18} \
+        clang-format-{16,17,18} \
         cmake \
         coreutils \
         curl \

--- a/runner/Dockerfile.ubuntu
+++ b/runner/Dockerfile.ubuntu
@@ -759,7 +759,7 @@ RUN bash -eux -o pipefail <<'EOF'
         iputils-ping \
         jq \
         libatomic1 \
-        libclang-dev \
+        libclang-{16,17,18}-dev \
         libbz2-1.0 \
         libexpat1 \
         libffi8 \


### PR DESCRIPTION
Tree-sitter needs clang in CI, and GH already has these installed by default, so I think it makes sense to add here :) thanks!