### PR TITLE
Preserve /var/lib/dpkg during image cleanup

### DIFF
--- a/runner/Dockerfile.ubuntu
+++ b/runner/Dockerfile.ubuntu
@@ -789,9 +789,10 @@ RUN bash -eux -o pipefail <<'EOF'
         exit 1
     fi
 
-    # Clean apt/dpkg cache
-    apt-get clean autoclean
-    rm -rf /var/lib/{apt,dpkg,cache,log}/
+    # Clean apt cache. Do NOT remove /var/lib/dpkg — it holds the package
+    # database and lock files; without it, `apt-get install` fails for users.
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
     # Add a user which will run the github actions
     groupadd -f docker
@@ -932,9 +933,10 @@ RUN bash -eux -o pipefail <<'EOF'
     # Install dependencies for the runner (if any)
     sudo /home/runner/actions-runner/cached/${RUNNER_VERSION}/bin/installdependencies.sh
 
-    # Clean apt/dpkg cache
-    sudo apt-get clean autoclean
-    sudo rm -rf /var/lib/{apt,dpkg,cache,log}/
+    # Clean apt cache. Do NOT remove /var/lib/dpkg — it holds the package
+    # database and lock files; without it, `apt-get install` fails for users.
+    sudo apt-get clean
+    sudo rm -rf /var/lib/apt/lists/*
 EOF
 
 ENTRYPOINT ["/usr/local/bin/docker-init", "--", "/usr/local/bin/riscv-runner-entrypoint.sh"]


### PR DESCRIPTION
Commit db6ecb8 ("Better cleaning of apt/dpkg cache") replaced `rm -rf /var/lib/apt/lists/*` with `rm -rf /var/lib/{apt,dpkg,cache,log}/`, which also wipes /var/lib/dpkg — the dpkg state database and lock files. As a result, `sudo apt-get install` on the resulting ubuntu-24.04-riscv runner image fails with:

    E: Could not open lock file /var/lib/dpkg/lock-frontend - open (2: No such file or directory)

Restore the narrower cleanup that removes only regenerable caches (apt archives via `apt-get clean`, and /var/lib/apt/lists/*) and leaves dpkg's state intact, in both the main image stage and the post- installdependencies stage.

Fixes #63