### PR TITLE
Update documentation to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,34 @@
 
 Container images for running GitHub Actions runners on RISC-V (`linux/riscv64`).
 
-Images are built with QEMU cross-compilation via Docker Buildx and pushed to the Scaleway Container Registry.
+Built natively on RISC-V hardware and pushed to the Scaleway Container Registry.
 
 ## Images
 
 ### Runner (`runner/Dockerfile.ubuntu`)
 
-GitHub Actions runner based on Ubuntu. Available variants:
+Single unified GitHub Actions runner image based on Ubuntu, with `dockerd` and `containerd` bundled in (no separate Docker-in-Docker sidecar). Available variants:
 
 | Tag | Base |
 |-----|------|
-| `riscv-runner:ubuntu-24.04-<version>` | Ubuntu 24.04 |
-| `riscv-runner:ubuntu-26.04-<version>` | Ubuntu 26.04 |
+| `riscv-runner:ubuntu-24.04-<suffix>` | Ubuntu 24.04 |
+| `riscv-runner:ubuntu-26.04-<suffix>` | Ubuntu 26.04 |
+
+`<suffix>` is `latest` for builds from `main` and the branch slug otherwise (e.g. `staging`).
 
 The runner image includes:
 - [GitHub Actions Runner for RISC-V](https://github.com/alitariq4589/github-runner-riscv) (built with .NET 8)
-- Java 17, 21, 25 (default), from [Adoptium Temurin](https://adoptium.net/)
-- Python 3.10, 3.11, 3.12 (default), 3.13, 3.13t (free threaded), 3.14, 3.14t (free threaded)
-- Apache Ant 1.10.14, Gradle 9.3.1, Apache Maven 3.9.12
+- Java (Adoptium Temurin)
+- Python (including free-threaded variants)
+- Node.js, Go, Rust
+- Apache Ant, Gradle, Apache Maven
 - Docker CLI, Docker Buildx, Docker Compose
-- Bundled `dockerd` + `containerd` (unified Docker-in-Docker — no sidecar required)
+- Bundled `dockerd` + `containerd` (unified Docker-in-Docker, no sidecar required)
 - git, curl, wget, jq, sudo, and many more CLI tools
 
-We are aiming to match packages installed in the [official GitHub Actions runner images](https://github.com/actions/runner-images/blob/ubuntu24/20260302.42/images/ubuntu/Ubuntu2404-Readme.md). **Let us know if any package you depend on is missing!**
+Pinned versions for every tool above live in [`versions-map.json`](versions-map.json) and are kept in sync with upstream by [`scripts/update-versions.py`](scripts/update-versions.py).
+
+The image aims to match the packages installed in the [official GitHub Actions runner images](https://github.com/actions/runner-images). **Let us know if any package you depend on is missing!**
 
 The entrypoint (`runner/riscv-runner-entrypoint.sh`) uses `docker-init` (tini) as PID 1, starts `containerd` and `dockerd` in the background (unix socket, no TLS), then drops to the `runner` user to execute `./run.sh --jitconfig $RUNNER_JITCONFIG`. Because `dockerd` and the runner share the same filesystem, Docker bind mounts from inside jobs (e.g. `-v /home/runner/_work:/work`) work as expected.
 
@@ -38,16 +43,17 @@ Build args:
 ├── .github/workflows/
 │   └── release.yml                    # CI: builds and pushes the runner image
 ├── runner/
-│   ├── Dockerfile.ubuntu              # GitHub Actions runner image (unified DinD)
+│   ├── Dockerfile.ubuntu              # Unified runner image (with bundled dockerd + containerd)
 │   └── riscv-runner-entrypoint.sh     # PID-1 entrypoint: starts containerd+dockerd, execs runner
+├── scripts/
+│   └── update-versions.py             # Syncs pinned versions from upstream
+├── versions-map.json                  # Pinned versions for all bundled tools
 └── LICENSE
 ```
 
 ## CI/CD
 
-The GitHub Actions workflow (`.github/workflows/release.yml`) triggers on pushes to `main`, on a daily schedule, and manual dispatch. A single `build-runner` job builds Ubuntu 24.04 and 26.04 runner images via a matrix.
-
-The Ubuntu 24.04 runner builds natively on `ubuntu-24.04-riscv` self-hosted runners. The Ubuntu 26.04 runner builds with QEMU cross-compilation on `ubuntu-latest`. Images are pushed to the Scaleway Container Registry. GitHub Actions cache (`type=gha`) is used to speed up builds. A concurrency group ensures only the latest run per branch executes.
+The GitHub Actions workflow (`.github/workflows/release.yml`) triggers on pushes to `main` and `staging`, on a daily schedule, and via manual dispatch. A single `build-runner` job builds the runner image natively on `ubuntu-24.04-riscv` self-hosted RISC-V runners. Images are pushed to the Scaleway Container Registry. GitHub Actions cache (`type=gha`) is used to speed up builds. A concurrency group ensures only the latest run per branch executes.
 
 ## Building Locally
 
@@ -57,12 +63,11 @@ docker buildx build \
   --platform linux/riscv64 \
   --file runner/Dockerfile.ubuntu \
   --build-arg OS_VERSION=24.04 \
-  --build-arg RUNNER_VERSION=2.333.1 \
   --tag riscv-runner:ubuntu-24.04 \
   runner
 ```
 
-When cross-compiling, requires Docker with QEMU user-static registered (`docker run --rm --privileged multiarch/qemu-user-static --reset -p yes`).
+Best run on a RISC-V host (`linux/riscv64`) so the build does not need any emulation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built natively on RISC-V hardware and pushed to the Scaleway Container Registry.
 
 ### Runner (`runner/Dockerfile.ubuntu`)
 
-Single unified GitHub Actions runner image based on Ubuntu, with `dockerd` and `containerd` bundled in (no separate Docker-in-Docker sidecar). Available variants:
+GitHub Actions runner image based on Ubuntu. Available variants:
 
 | Tag | Base |
 |-----|------|
@@ -18,20 +18,17 @@ Single unified GitHub Actions runner image based on Ubuntu, with `dockerd` and `
 `<suffix>` is `latest` for builds from `main` and the branch slug otherwise (e.g. `staging`).
 
 The runner image includes:
-- [GitHub Actions Runner for RISC-V](https://github.com/alitariq4589/github-runner-riscv) (built with .NET 8)
+- [GitHub Actions Runner for RISC-V](https://github.com/Cloud-V-10xE/github-runner-riscv) (built with .NET 8)
 - Java (Adoptium Temurin)
 - Python (including free-threaded variants)
 - Node.js, Go, Rust
 - Apache Ant, Gradle, Apache Maven
-- Docker CLI, Docker Buildx, Docker Compose
-- Bundled `dockerd` + `containerd` (unified Docker-in-Docker, no sidecar required)
+- Docker (CLI + daemon, Buildx, Compose), podman, buildah, skopeo, runc, kubectl
 - git, curl, wget, jq, sudo, and many more CLI tools
 
 Pinned versions for every tool above live in [`versions-map.json`](versions-map.json) and are kept in sync with upstream by [`scripts/update-versions.py`](scripts/update-versions.py).
 
 The image aims to match the packages installed in the [official GitHub Actions runner images](https://github.com/actions/runner-images). **Let us know if any package you depend on is missing!**
-
-The entrypoint (`runner/riscv-runner-entrypoint.sh`) uses `docker-init` (tini) as PID 1, starts `containerd` and `dockerd` in the background (unix socket, no TLS), then drops to the `runner` user to execute `./run.sh --jitconfig $RUNNER_JITCONFIG`. Because `dockerd` and the runner share the same filesystem, Docker bind mounts from inside jobs (e.g. `-v /home/runner/_work:/work`) work as expected.
 
 Build args:
 - `OS_VERSION` — Ubuntu base image version (default: `latest`)
@@ -43,8 +40,8 @@ Build args:
 ├── .github/workflows/
 │   └── release.yml                    # CI: builds and pushes the runner image
 ├── runner/
-│   ├── Dockerfile.ubuntu              # Unified runner image (with bundled dockerd + containerd)
-│   └── riscv-runner-entrypoint.sh     # PID-1 entrypoint: starts containerd+dockerd, execs runner
+│   ├── Dockerfile.ubuntu              # Runner image
+│   └── riscv-runner-entrypoint.sh     # PID-1 entrypoint, execs the runner
 ├── scripts/
 │   └── update-versions.py             # Syncs pinned versions from upstream
 ├── versions-map.json                  # Pinned versions for all bundled tools


### PR DESCRIPTION
## Summary

Refresh the README so it matches the current state of the build and the unified runner image.

- Drop hardcoded versions; point to [`versions-map.json`](versions-map.json) so the README does not drift each time a dependency is bumped.
- Drop the QEMU cross-compilation language. Builds run natively on `ubuntu-24.04-riscv` self-hosted runners.
- Tone down the dedicated dockerd/containerd narration. Docker is one of many tools in the image (alongside Java, Go, Python, podman, etc.).
- Fix the GitHub Actions Runner for RISC-V link to point at [Cloud-V-10xE/github-runner-riscv](https://github.com/Cloud-V-10xE/github-runner-riscv) (the actual upstream the Dockerfile pulls from).

## Test plan

- [ ] Re-read the rendered README on GitHub after pushing — links resolve, sections flow